### PR TITLE
Run skopeo and oci-image-tool directly from the faas server

### DIFF
--- a/kontain-faas/server/Dockerfile
+++ b/kontain-faas/server/Dockerfile
@@ -50,6 +50,3 @@ RUN dnf install -y yajl-devel libseccomp-devel
 # net-tools can help with network issures inside the container
 RUN dnf install -y skopeo net-tools bind-utils iputils
 COPY oci-image-tool /usr/bin
-
-# Get the kontain programs into the container
-COPY faaskrun.sh /opt/kontain/bin

--- a/kontain-faas/server/Dockerfile
+++ b/kontain-faas/server/Dockerfile
@@ -14,6 +14,14 @@
 FROM fedora:31
 
 ARG KM_TAR
+ARG DHOST
+
+# Hack, hack hack.  We need a more general way to access the container repository inside of minikube
+# or the real kube for that matter.  This stuff was just determined empirically.
+ENV DOCKER_HOST=$DHOST
+ENV DOCKER_CERT_PATH=/root/.minikube/certs
+RUN mkdir -p /root/.minikube/certs
+COPY minikubecerts /root/.minikube/certs
 
 # Go programs compiled on linux expect the GLIBC dynamic loader.
 # When using "FROM alpine:3.7" we don't have the gnu loader.
@@ -37,6 +45,11 @@ COPY test_funcs/test_func_data_with_hc.json /kontain
 
 # Get libraries for krun
 RUN dnf install -y yajl-devel libseccomp-devel
+# We need skopeo to pull the function containers and image tool to unpack the container into
+# a bundle for krun.
+# net-tools can help with network issures inside the container
+RUN dnf install -y skopeo net-tools bind-utils iputils
+COPY oci-image-tool /usr/bin
 
 # Get the kontain programs into the container
 COPY faaskrun.sh /opt/kontain/bin

--- a/kontain-faas/server/README.md
+++ b/kontain-faas/server/README.md
@@ -5,10 +5,14 @@ line below, the assumption is `kontain.tar.gz` was copied here.
 
 - Copy ${KM_TOP}/tools/bin/kontain-gcc to /opt/kontain/bin
 - Copy ${KM_TOP}/include/km_hcalls.h to /opt/kontain/include
+- Copy your minikube certs into the container build area: cd YouR_BuilD_AreA; mkdir -p minkubecerts; cp $DOCKER_CERT_PATH minikubecerts
 
 - Point to docker daemon inside minikube: `eval $(minikube docker-env)`
+- Build oci-image-tool: `bash build-oci-image-tool.bash`
+- Build the faas server: `bash build-server.bash`
 - Build the test functions mentioned below before running the next step
-- Build kontain-faas-server docker container: `docker build -t kontain-faas-server -f Dockerfile --build-arg KM_TAR=kontain.tar.gz .`
+- Build kontain-faas-server docker container: `docker build -t kontain-faas-server -f Dockerfile --build-arg KM_TAR=kontain.tar.gz --build-arg DHOST=$DOCKER_HOST .`
+- Create a kontain kubernetes namespace if you don't have one: kubectl create namespace kontain
 - Start kontain-faas-server in minikube: `kubectl create -f server.yaml`
 - Get the faas pod name by running: `kubectl get pod -n kontain`, you should see output like this:
 ```
@@ -24,12 +28,12 @@ nginx-557dcdb56b-r65mp                1/1     Running                 3         
 The name is expected to be the name of an executable in the test_funcs directory.  The .km exention is added to the name by the faas server.
 I've currently tested with the function name: test_func_data_with_hc
 - When you are done testing, interrupt `kubectl port-forward ....` with control-C.
-- If you are having problems, get the faas services logs: `kubectl logs kontain-faas-server-d68b7b6bb-6xqbt` but put the current name in the command.
+- If you are having problems, get the faas services logs: `kubectl logs -n kontain kontain-faas-server-d68b7b6bb-6xqbt` but put the current pod name in the command.
 - To stop kontain-faas-server in minikube: `kubectl delete -f server.yaml`
 
 ## Example Function
 
-There are example functions in the test_funcs directory.
+There are example functions and containers made for them in the test_funcs directory.
 To build the faas test functions:
 
 - make -C test_funcs all

--- a/kontain-faas/server/build-oci-image-tool.bash
+++ b/kontain-faas/server/build-oci-image-tool.bash
@@ -8,9 +8,7 @@ fi
 rm -f go.mod go.sum
 
 go get -d github.com/opencontainers/image-tools/cmd/oci-image-tool
-pushd $GOPATH/src/github.com/opencontainers/image-tools/
-make tool
-popd
+make -C $GOPATH/src/github.com/opencontainers/image-tools tool
 
 # The oci-image-tool executable should be $GOPATH/src/github.com/opencontainers/image-tools/oci-image-tool
 cp $GOPATH/src/github.com/opencontainers/image-tools/oci-image-tool .

--- a/kontain-faas/server/build-oci-image-tool.bash
+++ b/kontain-faas/server/build-oci-image-tool.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "$GOPATH" ]
+then
+    export GOPATH=$HOME/go
+fi
+
+rm -f go.mod go.sum
+
+go get -d github.com/opencontainers/image-tools/cmd/oci-image-tool
+pushd $GOPATH/src/github.com/opencontainers/image-tools/
+make tool
+popd
+
+# The oci-image-tool executable should be $GOPATH/src/github.com/opencontainers/image-tools/oci-image-tool
+cp $GOPATH/src/github.com/opencontainers/image-tools/oci-image-tool .

--- a/kontain-faas/server/kontain-function-root.go
+++ b/kontain-faas/server/kontain-function-root.go
@@ -4,6 +4,10 @@ import (
 	"io"
 	"os"
 	"path"
+	"os/exec"
+	"fmt"
+	"strings"
+	"time"
 )
 
 func kontainApiCopyFile(srcPath string, dstPath string) error {
@@ -54,4 +58,241 @@ func createKontainFunctionRootImage(rootPath string, containerId string, execPat
 
 func cleanupKontainFunctionRootImage(containerRootDir string) {
 	os.RemoveAll(containerRootDir)
+}
+
+func printDuration(tag string, start time.Time) {
+	t := time.Now()
+	delta := t.Sub(start)
+	fmt.Printf("%s took %f seconds\n", tag, delta.Seconds());
+}
+
+/*
+ * Create a config.json file in the passed bundle directory.
+ * We substitute values into our model config.json string and then create the file and
+ * write our complated model to it.  On failure any config.json created will be removed
+ * before returning.
+ * Returns:
+ *   nil - success
+ *   != nil - something failed, the returned error might be helpful
+ */
+func createConfigJson(configPath string, faasName string, faasDataDir string, requestFile string, responseFile string)  error {
+	configJsonModel := `
+{
+    "ociVersion": "1.0.0",
+    "process": {
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "terminal": false,
+        "args": [
+            "/opt/kontain/bin/km",
+            "--input-data",
+            "/kontain/$FAASINPUT$",
+            "--output-data",
+            "/kontain/$FAASOUTPUT$",
+            "/usr/bin/$FAASFUNC$.km"
+        ],
+        "env": [
+            "PATH=/usr/bin",
+            "TERM=xterm"
+        ],
+        "cwd": "/",
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs",
+        "readonly": true
+    },
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc"
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "ro"
+            ]
+        },
+        {
+            "destination": "/sys/fs/cgroup",
+            "type": "cgroup",
+            "source": "cgroup",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "relatime",
+                "rw"
+            ]
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/kontain",
+            "type": "none",
+            "source": "$FAASDATADIR$",
+            "options": ["bind", "rw"]
+        }
+    ],
+    "linux": {
+        "rootfsPropagation": "rprivate",
+        "namespaces": [
+            {
+                "type": "mount"
+            },
+            {
+                "type": "pid"
+            },
+            {
+                "type": "user"
+            },
+            {
+                "type": "ipc"
+            },
+            {
+                "type": "cgroup"
+            }
+        ]
+    }
+}
+`
+	start := time.Now()
+
+	// Substitute the function and instance specific values into our config.json pattern string.
+	configJson := strings.ReplaceAll(configJsonModel, "$FAASINPUT$", requestFile)
+	configJson = strings.ReplaceAll(configJson, "$FAASOUTPUT$", responseFile)
+	configJson = strings.ReplaceAll(configJson, "$FAASFUNC$", faasName)
+	configJson = strings.ReplaceAll(configJson, "$FAASDATADIR$", faasDataDir)
+
+	// Write the config.json file to the bundle directory.
+	file, err := os.Create(configPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(configJson)
+	if err != nil {
+		os.Remove(configPath)
+		return err
+	}
+	printDuration("build config.json", start)
+	return nil
+}
+
+/*
+ * Given the base directory where container images and runtime bundles are kept,
+ * and the name of the desired function, pull the needed function container and
+ * setup the runtime bundle for that function.
+ * Then return the path to the base of the runtime bundle.  This base of the runtime
+ * bundle will contain the directory rootfs which will contain the container's files.
+ * rootfs is supplied to krun via the config.json that some other function will need
+ * to build.
+ * If there is a failure, the error return value will be non-nil and anything this function
+ * created before the failure will be removed.
+ * Until we start reusing the runtime bundles the caller must delete the runtime bundle
+ * once it is done using it.
+ */
+func getFunctionBundle(baseDir string, faasName string, containerId string) (string, error) {
+	functionImageDir := baseDir + "/function_container_images/" + faasName
+	bundleDir := baseDir + "/" + faasName
+
+	// If we have a copy of the function container, use it
+	_, err := os.Stat(functionImageDir)
+	if err == nil {
+		fmt.Printf("Using existing bundle for %s\n", faasName)
+		return bundleDir, nil
+	}
+
+	fmt.Printf("Creating bundle for %s\n", faasName)
+
+	start := time.Now()
+	// make a directory for the container image
+	err = os.MkdirAll(functionImageDir, 0755)
+	if err != nil {
+		return "", err
+	}
+	// pull the container image using skopeo
+	dockerHost := os.Getenv("DOCKER_HOST")
+	dockerCertPath := os.Getenv("DOCKER_CERT_PATH")
+	execCmd := exec.Command("/usr/bin/skopeo", "copy", "--src-daemon-host", dockerHost, "--src-cert-dir", dockerCertPath, 
+			"docker-daemon:" + faasName + ":latest",
+			"oci:" + functionImageDir + ":latest");
+	output, err := execCmd.CombinedOutput()
+	fmt.Printf("Output of %s:\n%s\n==============\n", execCmd.String(), output)
+	if err != nil {
+		os.RemoveAll(functionImageDir)
+		return "", err
+	}
+	printDuration("get container", start);
+
+
+	// Make a directory for the runtime bundle.
+	start = time.Now()
+	err = os.MkdirAll(bundleDir, 0755)
+	if err != nil {
+		os.RemoveAll(functionImageDir)
+		return "", err
+	}
+	// build the runtime bundle using oci-image-tool
+	execCmd = exec.Command("/usr/bin/oci-image-tool", "unpack", "--ref", "name=latest", functionImageDir, bundleDir + "/rootfs")
+	output, err = execCmd.CombinedOutput()
+	fmt.Printf("Output of %s:\n%s\n==============\n", execCmd.String(), output)
+	if err != nil {
+		os.RemoveAll(functionImageDir)
+		os.RemoveAll(bundleDir);
+		return "", err
+	}
+	printDuration("unpack runtime bundle", start)
+
+	return bundleDir, nil
 }

--- a/kontain-faas/server/test_funcs/Makefile
+++ b/kontain-faas/server/test_funcs/Makefile
@@ -13,6 +13,7 @@ test_func_km: test_func_km.c
 clean:
 	rm -f test_func1 test_func_km test_func_data_with_hc.km
 
-images: test_func_km
+images: test_func1 test_func_km test_func_data_with_hc.km
 	docker build -t test_func_1 -f test_func_1.dockerfile  .
 	docker build -t test_func_2 -f test_func_2.dockerfile  .
+	docker build -t test_func_data_with_hc -f test_func_data_with_hc.dockerfile .

--- a/kontain-faas/server/test_funcs/test_func_data_with_hc.dockerfile
+++ b/kontain-faas/server/test_funcs/test_func_data_with_hc.dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+COPY test_func_data_with_hc.km /usr/bin/test_func_data_with_hc.km
+
+ENTRYPOINT [ "/usr/bin/test_func_data_with_hc.km" ]


### PR DESCRIPTION
skopeo and oci-image-tool are run once for each function on its first invocation.
Build the function's config.json for each function invocation.
There are interim changes to faaskrun.sh that pulled the function container and unpacked
it before before running krun.  Since the faas server now pulls the container, unpacks it,
and starts krun directly, the faaskrun.sh script is now unused.  It will be removed eventually.

This was lightly tested using the test_func_data_with_hc function.

Added some code to time skopeo, oci-image-tool, and building config.json.  Here are some numbers it is reporting:
get container took 0.185895 seconds
unpack runtime bundle took 0.091700 seconds
build config.json took 0.000058 seconds
build config.json took 0.000044 seconds
build config.json took 0.000036 seconds
build config.json took 0.000070 seconds
build config.json took 0.000098 seconds
build config.json took 0.000040 seconds
build config.json took 0.000252 seconds
build config.json took 0.000042 seconds
build config.json took 0.000187 seconds
build config.json took 0.000039 seconds
build config.json took 0.000033 seconds
build config.json took 0.000243 seconds
build config.json took 0.000184 seconds
build config.json took 0.000043 seconds
